### PR TITLE
Fix invalid byte sequence in UTF-8

### DIFF
--- a/fluent-plugin-notifier.gemspec
+++ b/fluent-plugin-notifier.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_development_dependency "test-unit"
   gem.add_development_dependency "rake"
   gem.add_runtime_dependency "fluentd"
 end

--- a/test/plugin/test_out_notifier.rb
+++ b/test/plugin/test_out_notifier.rb
@@ -112,4 +112,14 @@ class NotifierOutputTest < Test::Unit::TestCase
     end
     assert_equal 0, d.emits.size
   end
+
+  def test_emit_invalid_byte
+    invalid_utf8 = "\xff".force_encoding('UTF-8')
+    d = create_driver
+    assert_nothing_raised {
+      d.run do
+        d.emit({'num1' => 60, 'message' => "foo bar WARNING #{invalid_utf8}", 'numfield' => '30', 'textfield' => 'TargetX'})
+      end
+    }
+  end
 end

--- a/test/plugin/test_out_notifier.rb
+++ b/test/plugin/test_out_notifier.rb
@@ -1,6 +1,10 @@
 require 'helper'
 
 class NotifierOutputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
   CONFIG = %[
   type notifier
   input_tag_remove_prefix test


### PR DESCRIPTION
Hi.
Apply the invalid byte patch.

ref: https://github.com/tagomoris/fluent-plugin-parser/pull/3
```
2015-11-13 12:42:55 +0900 [warn]: emit transaction failed: error_class=ArgumentError error="invalid byte sequence in UTF-8" tag="muu_www.php_log_application_log"
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:404:in `match'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:404:in `check'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:178:in `block (3 levels) in check'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:175:in `each'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:175:in `block (2 levels) in check'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:163:in `each'
  2015-11-13 12:42:55 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-notifier-0.2.3/lib/fluent/plugin/out_notifier.rb:163:in `block in check'
```
